### PR TITLE
Test issue on windows - resolves #4

### DIFF
--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -32,5 +32,5 @@ Extract Tar Bzipped2 File
 
 
 Is File In Archive
-    Archive Should Contain File  ${CURDIR}${/}test.zip  tests${/}testcase.txt
-    Archive Should Contain File  ${CURDIR}${/}test.tar  test${/}testcase.txt
+    Archive Should Contain File  ${CURDIR}${/}test.zip  tests/testcase.txt
+    Archive Should Contain File  ${CURDIR}${/}test.tar  test/testcase.txt


### PR DESCRIPTION
This fixes the issue related to running tests on windows (they fail because of OS sepatator is used instead of the / separator when accessing interna entries in zip file)
