### PR TITLE
Fixed bug when archive and keyword where executed in diffret os.

### DIFF
--- a/ArchiveLibrary/keywords.py
+++ b/ArchiveLibrary/keywords.py
@@ -75,6 +75,7 @@ class ArchiveKeywords(object):
             files = zipfile.ZipFile(zfile).namelist()
         else:
             files = tarfile.open(name=zfile).getnames()
+        files = [os.path.normpath(item) for item in files]
 
         self.collections.list_should_contain_value(files, filename)
 


### PR DESCRIPTION
If the archive was created in linux os and Archive Should
Contain File keyword was executed in windows os, then the
path separator in the zip file was with backslash but Robot
Framework ${/} variable would use forward slash as folder
separator. This causes the keyword to fail in this
scenario. Fixed that paths from the archive are
normalised before doing a comparison does the archive
contain the file.