### PR TITLE
Support for including subdirectories in zip create

### DIFF
--- a/ArchiveLibrary/keywords.py
+++ b/ArchiveLibrary/keywords.py
@@ -2,7 +2,7 @@
 
 from robot.libraries.Collections import Collections
 from robot.libraries.OperatingSystem import OperatingSystem
-from .utils import Unzip, Untar
+from .utils import Unzip, Untar, return_files_lists
 import os
 import tarfile
 import zipfile

--- a/ArchiveLibrary/keywords.py
+++ b/ArchiveLibrary/keywords.py
@@ -97,20 +97,35 @@ class ArchiveKeywords(object):
         for name in files:
             tar.add(directory + name, arcname=name)
         tar.close()
-		
-    def create_zip_from_files_in_directory(self, directory, filename):
+
+    def create_zip_from_files_in_directory(self, directory, filename, sub_directories=False):
         ''' Take all files in a directory and create a zip package from them
 
         `directory` Path to the directory that holds our files
 
         `filename` Path to our destination ZIP package.
+
+        `sub_directories` Shall files in sub-directories be included - False by default.
         '''
         if not directory.endswith("/"):
             directory = directory + "/"
         zip = zipfile.ZipFile(filename, "w")
-        files = os.listdir(directory)
-        for name in files:
-            zip.write(directory + name, arcname=name)
+
+        if not sub_directories:
+            files = os.listdir(directory)
+            for name in files:
+                zip.write(directory + name, arcname=name)
+        else:
+            for path, _, files in os.walk(directory):
+                for target_file in files:
+                    file_to_archive = os.path.join(path, target_file)
+                    # generate the "relative" path by getting rid of the starting directory
+                    file_name = path.replace(directory, '')
+                    # the final filename is the relative path plus the file's name
+                    file_name = os.path.join(file_name, target_file)
+
+                    zip.write(file_to_archive, arcname=file_name)
+
         zip.close()
 
 if __name__ == '__main__':

--- a/ArchiveLibrary/keywords.py
+++ b/ArchiveLibrary/keywords.py
@@ -83,19 +83,21 @@ class ArchiveKeywords(object):
 
         self.collections.list_should_contain_value(files, filename)
 
-    def create_tar_from_files_in_directory(self, directory, filename):
+    def create_tar_from_files_in_directory(self, directory, filename, sub_directories=False):
         ''' Take all files in a directory and create a tar package from them
 
         `directory` Path to the directory that holds our files
 
         `filename` Path to our destination TAR package.
+        
+        `sub_directories` Shall files in sub-directories be included - False by default.        
         '''
-        if not directory.endswith("/"):
-            directory = directory + "/"
         tar = tarfile.open(filename, "w")
-        files = os.listdir(directory)
-        for name in files:
-            tar.add(directory + name, arcname=name)
+        files = return_files_lists(directory, sub_directories)
+        
+        for filepath, name in files:
+            tar.add(filepath, arcname=name)
+        
         tar.close()
 
     def create_zip_from_files_in_directory(self, directory, filename, sub_directories=False):
@@ -107,24 +109,11 @@ class ArchiveKeywords(object):
 
         `sub_directories` Shall files in sub-directories be included - False by default.
         '''
-        if not directory.endswith("/"):
-            directory = directory + "/"
-        zip = zipfile.ZipFile(filename, "w")
-
-        if not sub_directories:
-            files = os.listdir(directory)
-            for name in files:
-                zip.write(directory + name, arcname=name)
-        else:
-            for path, _, files in os.walk(directory):
-                for target_file in files:
-                    file_to_archive = os.path.join(path, target_file)
-                    # generate the "relative" path by getting rid of the starting directory
-                    file_name = path.replace(directory, '')
-                    # the final filename is the relative path plus the file's name
-                    file_name = os.path.join(file_name, target_file)
-
-                    zip.write(file_to_archive, arcname=file_name)
+        zip = zipfile.ZipFile(filename, "w")        
+        files = return_files_lists(directory, sub_directories)
+        
+        for filepath, name in files:
+            zip.write(filepath, arcname=name)
 
         zip.close()
 

--- a/ArchiveLibrary/keywords.py
+++ b/ArchiveLibrary/keywords.py
@@ -109,13 +109,13 @@ class ArchiveKeywords(object):
 
         `sub_directories` Shall files in sub-directories be included - False by default.
         '''
-        zip = zipfile.ZipFile(filename, "w")        
+        the_zip = zipfile.ZipFile(filename, "w")
         files = return_files_lists(directory, sub_directories)
         
         for filepath, name in files:
-            zip.write(filepath, arcname=name)
+            the_zip.write(filepath, arcname=name)
 
-        zip.close()
+        the_zip.close()
 
 if __name__ == '__main__':
     al = ArchiveKeywords()

--- a/ArchiveLibrary/keywords.py
+++ b/ArchiveLibrary/keywords.py
@@ -83,14 +83,14 @@ class ArchiveKeywords(object):
 
         self.collections.list_should_contain_value(files, filename)
 
-    def create_tar_from_files_in_directory(self, directory, filename, sub_directories=False):
+    def create_tar_from_files_in_directory(self, directory, filename, sub_directories=True):
         ''' Take all files in a directory and create a tar package from them
 
         `directory` Path to the directory that holds our files
 
         `filename` Path to our destination TAR package.
         
-        `sub_directories` Shall files in sub-directories be included - False by default.        
+        `sub_directories` Shall files in sub-directories be included - True by default.        
         '''
         tar = tarfile.open(filename, "w")
         files = return_files_lists(directory, sub_directories)

--- a/ArchiveLibrary/utils.py
+++ b/ArchiveLibrary/utils.py
@@ -78,14 +78,14 @@ class Untar(Archive):
         return [name for name in tff.getnames() if name.endswith('/')]
 
        
-def return_files_lists(directory,include_sub_directories=False):
+def return_files_lists(directory, include_sub_directories=False):
     """ Returns the files in a given directory, and optionally it's subdirectories.
         The return value is a list of tuples, the 1st tuple member - the file's path, 
           the 2nd - its name for the archive. """
   
     result = []
         
-    if not sub_directories:
+    if not include_sub_directories:
         if not directory.endswith("/"):
             directory = directory + "/"
         files = os.listdir(directory)

--- a/ArchiveLibrary/utils.py
+++ b/ArchiveLibrary/utils.py
@@ -86,11 +86,10 @@ def return_files_lists(directory, include_sub_directories=False):
     result = []
         
     if not include_sub_directories:
-        if not directory.endswith("/"):
-            directory = directory + "/"
-        files = os.listdir(directory)
-        for name in files:
-            result.append((directory + name, name))
+        files = (a_file for a_file in os.listdir(directory) if os.path.isfile(os.path.join(directory, a_file)))
+        for file_name in files:
+            file_to_archive = os.path.join(directory, file_name)
+            result.append((file_to_archive, file_name))
     else:
         for path, _, files in os.walk(directory):
             for target_file in files:

--- a/ArchiveLibrary/utils.py
+++ b/ArchiveLibrary/utils.py
@@ -77,7 +77,34 @@ class Untar(Archive):
         tff = tarfile.open(name=tfile)
         return [name for name in tff.getnames() if name.endswith('/')]
 
+       
+def return_files_lists(directory,include_sub_directories=False):
+    """ Returns the files in a given directory, and optionally it's subdirectories.
+        The return value is a list of tuples, the 1st tuple member - the file's path, 
+          the 2nd - its name for the archive. """
+  
+    result = []
+        
+    if not sub_directories:
+        if not directory.endswith("/"):
+            directory = directory + "/"
+        files = os.listdir(directory)
+        for name in files:
+            result.append((directory + name, arcname=name))
+    else:
+        for path, _, files in os.walk(directory):
+            for target_file in files:
+                file_to_archive = os.path.join(path, target_file)
+                # generate the "relative" path by getting rid of the starting directory
+                file_name = path.replace(directory, '')
+                # the final filename is the relative path plus the file's name
+                file_name = os.path.join(file_name, target_file)
+              
+                result.append((file_to_archive, file_name))
+   
+    return result
 
+   
 if __name__ == "__main__":
     ut = Untar()
     ut.extract(r"/tmp/test.tar", r"/tmp/testout")

--- a/ArchiveLibrary/utils.py
+++ b/ArchiveLibrary/utils.py
@@ -90,7 +90,7 @@ def return_files_lists(directory,include_sub_directories=False):
             directory = directory + "/"
         files = os.listdir(directory)
         for name in files:
-            result.append((directory + name, arcname=name))
+            result.append((directory + name, name))
     else:
         for path, _, files in os.walk(directory):
             for target_file in files:

--- a/ArchiveLibrary/version.py
+++ b/ArchiveLibrary/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.3.2'
+VERSION = '0.3.3'

--- a/tests/FilesToTar/subdir/file3.txt
+++ b/tests/FilesToTar/subdir/file3.txt
@@ -1,0 +1,1 @@
+this is testfile 3

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -65,4 +65,15 @@ Create ZIP Package from files in directory
     Create zip from Files in directory    ${CURDIR}${/}FilesToTar    ${zipfilename}
     Archive Should Contain File    ${zipfilename}    file1.txt
     Archive Should Contain File    ${zipfilename}    file2.txt
+    Run Keyword And Expect Error   *does not contain value 'subdir\\file3.txt'*
+                       ...     Archive Should Contain File    ${zipfilename}    subdir\\file3.txt
+    Remove File    ${zipfilename}
+
+Create ZIP Package from files in directory and subdirectory
+    ${zipfilename}=    set variable    newZipFile.zip
+    Remove File    ${zipfilename}
+    Create zip from Files in directory    ${CURDIR}${/}FilesToTar    ${zipfilename}     sub_directories=${true}
+    Archive Should Contain File    ${zipfilename}    file1.txt
+    Archive Should Contain File    ${zipfilename}    file2.txt
+    Archive Should Contain File    ${zipfilename}    subdir\\file3.txt
     Remove File    ${zipfilename}

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -57,17 +57,17 @@ Create TAR Package from files in directory
     Create tar from Files in directory    ${CURDIR}${/}FilesToTar    ${tarfilename}
     Archive Should Contain File    ${tarfilename}    file1.txt
     Archive Should Contain File    ${tarfilename}    file2.txt
-    Run Keyword And Expect Error   *does not contain value 'subdir${/}file3.txt'*
-                       ...     Archive Should Contain File    ${tarfilename}    subdir${/}file3.txt
+    Archive Should Contain File    ${tarfilename}    subdir${/}file3.txt
     Remove File    ${tarfilename}
     
-Create TAR Package from files in directory and subdirectory
+Create TAR Package from files in directory, without subdirectories
     ${tarfilename}=    set variable    newTarFile.tar
     Remove File    ${tarfilename}
-    Create tar from Files in directory    ${CURDIR}${/}FilesToTar    ${tarfilename}     sub_directories=${true}
+    Create tar from Files in directory    ${CURDIR}${/}FilesToTar    ${tarfilename}     sub_directories=${false}
     Archive Should Contain File    ${tarfilename}    file1.txt
     Archive Should Contain File    ${tarfilename}    file2.txt
-    Archive Should Contain File    ${tarfilename}    subdir${/}file3.txt
+    Run Keyword And Expect Error   *does not contain value 'subdir${/}file3.txt'*
+                       ...     Archive Should Contain File    ${tarfilename}    subdir${/}file3.txt
     Remove File    ${tarfilename}    
 
 Create ZIP Package from files in directory

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -58,7 +58,7 @@ Create TAR Package from files in directory
     Archive Should Contain File    ${tarfilename}    file1.txt
     Archive Should Contain File    ${tarfilename}    file2.txt
     Run Keyword And Expect Error   *does not contain value 'subdir${/}file3.txt'*
-                       ...     Archive Should Contain File    ${zipfilename}    subdir${/}file3.txt
+                       ...     Archive Should Contain File    ${tarfilename}    subdir${/}file3.txt
     Remove File    ${tarfilename}
     
 Create TAR Package from files in directory and subdirectory
@@ -67,7 +67,7 @@ Create TAR Package from files in directory and subdirectory
     Create tar from Files in directory    ${CURDIR}${/}FilesToTar    ${tarfilename}     sub_directories=${true}
     Archive Should Contain File    ${tarfilename}    file1.txt
     Archive Should Contain File    ${tarfilename}    file2.txt
-    Archive Should Contain File    ${zipfilename}    subdir${/}file3.txt
+    Archive Should Contain File    ${tarfilename}    subdir${/}file3.txt
     Remove File    ${tarfilename}    
 
 Create ZIP Package from files in directory

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -57,7 +57,18 @@ Create TAR Package from files in directory
     Create tar from Files in directory    ${CURDIR}${/}FilesToTar    ${tarfilename}
     Archive Should Contain File    ${tarfilename}    file1.txt
     Archive Should Contain File    ${tarfilename}    file2.txt
+    Run Keyword And Expect Error   *does not contain value 'subdir${/}file3.txt'*
+                       ...     Archive Should Contain File    ${zipfilename}    subdir${/}file3.txt
+    Remove File    ${tarfilename}
+    
+Create TAR Package from files in directory and subdirectory
+    ${tarfilename}=    set variable    newTarFile.tar
     Remove File    ${tarfilename}
+    Create tar from Files in directory    ${CURDIR}${/}FilesToTar    ${tarfilename}     sub_directories=${true}
+    Archive Should Contain File    ${tarfilename}    file1.txt
+    Archive Should Contain File    ${tarfilename}    file2.txt
+    Archive Should Contain File    ${zipfilename}    subdir${/}file3.txt
+    Remove File    ${tarfilename}    
 
 Create ZIP Package from files in directory
     ${zipfilename}=    set variable    newZipFile.zip

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -65,8 +65,8 @@ Create ZIP Package from files in directory
     Create zip from Files in directory    ${CURDIR}${/}FilesToTar    ${zipfilename}
     Archive Should Contain File    ${zipfilename}    file1.txt
     Archive Should Contain File    ${zipfilename}    file2.txt
-    Run Keyword And Expect Error   *does not contain value 'subdir\\file3.txt'*
-                       ...     Archive Should Contain File    ${zipfilename}    subdir\\file3.txt
+    Run Keyword And Expect Error   *does not contain value 'subdir${/}file3.txt'*
+                       ...     Archive Should Contain File    ${zipfilename}    subdir${/}file3.txt
     Remove File    ${zipfilename}
 
 Create ZIP Package from files in directory and subdirectory
@@ -75,5 +75,5 @@ Create ZIP Package from files in directory and subdirectory
     Create zip from Files in directory    ${CURDIR}${/}FilesToTar    ${zipfilename}     sub_directories=${true}
     Archive Should Contain File    ${zipfilename}    file1.txt
     Archive Should Contain File    ${zipfilename}    file2.txt
-    Archive Should Contain File    ${zipfilename}    subdir\\file3.txt
+    Archive Should Contain File    ${zipfilename}    subdir${/}file3.txt
     Remove File    ${zipfilename}


### PR DESCRIPTION
Optional parameter to the "Create zip from Files in directory" (_sub_directories_), setting it to true will include all files in all sub-directories in the zip file. It's default value is false, to preserve the current behavior.

This "request" actually [came from SO](http://stackoverflow.com/questions/42995992/zip-directory-with-subdirectories-in-robot-framework), so I guessed it would be fun & beneficial to add.