### PR TITLE
Control in create zip/tar should files in subdirectories be included

### DIFF
--- a/ArchiveLibrary/keywords.py
+++ b/ArchiveLibrary/keywords.py
@@ -2,7 +2,7 @@
 
 from robot.libraries.Collections import Collections
 from robot.libraries.OperatingSystem import OperatingSystem
-from .utils import Unzip, Untar
+from .utils import Unzip, Untar, return_files_lists
 import os
 import tarfile
 import zipfile
@@ -28,13 +28,13 @@ class ArchiveKeywords(object):
         `dest` optional destination folder. Assumes current working directory if it is none
                It will be created if It doesn't exist.
         '''
-        
+
         if dest:
             self.oslib.create_directory(dest)
             self.oslib.directory_should_exist(dest)
         else:
             dest = os.getcwd()
-       
+
         cwd = os.getcwd()
 
         unzipper = Unzip()
@@ -59,7 +59,7 @@ class ArchiveKeywords(object):
             self.oslib.create_directory(dest)
         else:
             dest = os.getcwd()
-            
+
         self.oslib.file_should_exist(tfile)
 
         untarrer = Untar()
@@ -83,35 +83,40 @@ class ArchiveKeywords(object):
 
         self.collections.list_should_contain_value(files, filename)
 
-    def create_tar_from_files_in_directory(self, directory, filename):
-        ''' Take all files in a directory and create a tar package from them
+    def create_tar_from_files_in_directory(self, directory, filename, sub_directories=True):
+        """ Take all files in a directory and create a tar package from them
 
         `directory` Path to the directory that holds our files
 
         `filename` Path to our destination TAR package.
-        '''
-        if not directory.endswith("/"):
-            directory = directory + "/"
+
+        `sub_directories` Shall files in sub-directories be included - True by default.        
+        """
         tar = tarfile.open(filename, "w")
-        files = os.listdir(directory)
-        for name in files:
-            tar.add(directory + name, arcname=name)
+        files = return_files_lists(directory, sub_directories)
+
+        for filepath, name in files:
+            tar.add(filepath, arcname=name)
+
         tar.close()
-		
-    def create_zip_from_files_in_directory(self, directory, filename):
-        ''' Take all files in a directory and create a zip package from them
+
+    def create_zip_from_files_in_directory(self, directory, filename, sub_directories=False):
+        """ Take all files in a directory and create a zip package from them
 
         `directory` Path to the directory that holds our files
 
         `filename` Path to our destination ZIP package.
-        '''
-        if not directory.endswith("/"):
-            directory = directory + "/"
-        zip = zipfile.ZipFile(filename, "w")
-        files = os.listdir(directory)
-        for name in files:
-            zip.write(directory + name, arcname=name)
-        zip.close()
+
+        `sub_directories` Shall files in sub-directories be included - False by default.
+        """
+        the_zip = zipfile.ZipFile(filename, "w")
+        files = return_files_lists(directory, sub_directories)
+
+        for filepath, name in files:
+            the_zip.write(filepath, arcname=name)
+
+        the_zip.close()
+
 
 if __name__ == '__main__':
     al = ArchiveKeywords()

--- a/ArchiveLibrary/utils.py
+++ b/ArchiveLibrary/utils.py
@@ -12,7 +12,6 @@ import tarfile
 
 
 class Archive(object):
-
     def _createstructure(self, file, dir):
         self._makedirs(self._listdirs(file), dir)
 
@@ -76,6 +75,30 @@ class Untar(Archive):
 
         tff = tarfile.open(name=tfile)
         return [name for name in tff.getnames() if name.endswith('/')]
+
+
+def return_files_lists(directory, include_sub_directories=False):
+    """ Returns the files in a given directory, and optionally it's subdirectories.
+        The return value is a list of tuples, the 1st tuple member - the file's path, 
+          the 2nd - its name for the archive. """
+
+    result = []
+
+    for path, _, files in os.walk(directory):
+        for target_file in files:
+            file_to_archive = os.path.join(path, target_file)
+            # generate the "relative" path by getting rid of the starting directory
+            file_name = path.replace(directory, '')
+            # the final filename is the relative path plus the file's name
+            file_name = os.path.join(file_name, target_file)
+
+            result.append((file_to_archive, file_name))
+
+        # if files in subdirs should not be returned, stop at the top-level folder
+        if not include_sub_directories:
+            break
+
+    return result
 
 
 if __name__ == "__main__":

--- a/tests/FilesToTar/subdir/file3.txt
+++ b/tests/FilesToTar/subdir/file3.txt
@@ -1,0 +1,1 @@
+this is testfile 3

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -57,7 +57,18 @@ Create TAR Package from files in directory
     Create tar from Files in directory    ${CURDIR}${/}FilesToTar    ${tarfilename}
     Archive Should Contain File    ${tarfilename}    file1.txt
     Archive Should Contain File    ${tarfilename}    file2.txt
+    Archive Should Contain File    ${tarfilename}    subdir${/}file3.txt
+    Remove File    ${tarfilename}
+    
+Create TAR Package from files in directory, without subdirectories
+    ${tarfilename}=    set variable    newTarFile.tar
     Remove File    ${tarfilename}
+    Create tar from Files in directory    ${CURDIR}${/}FilesToTar    ${tarfilename}     sub_directories=${false}
+    Archive Should Contain File    ${tarfilename}    file1.txt
+    Archive Should Contain File    ${tarfilename}    file2.txt
+    Run Keyword And Expect Error   *does not contain value 'subdir${/}file3.txt'*
+                       ...     Archive Should Contain File    ${tarfilename}    subdir${/}file3.txt
+    Remove File    ${tarfilename}    
 
 Create ZIP Package from files in directory
     ${zipfilename}=    set variable    newZipFile.zip
@@ -65,4 +76,15 @@ Create ZIP Package from files in directory
     Create zip from Files in directory    ${CURDIR}${/}FilesToTar    ${zipfilename}
     Archive Should Contain File    ${zipfilename}    file1.txt
     Archive Should Contain File    ${zipfilename}    file2.txt
+    Run Keyword And Expect Error   *does not contain value 'subdir${/}file3.txt'*
+                       ...     Archive Should Contain File    ${zipfilename}    subdir${/}file3.txt
+    Remove File    ${zipfilename}
+
+Create ZIP Package from files in directory and subdirectory
+    ${zipfilename}=    set variable    newZipFile.zip
+    Remove File    ${zipfilename}
+    Create zip from Files in directory    ${CURDIR}${/}FilesToTar    ${zipfilename}     sub_directories=${true}
+    Archive Should Contain File    ${zipfilename}    file1.txt
+    Archive Should Contain File    ${zipfilename}    file2.txt
+    Archive Should Contain File    ${zipfilename}    subdir${/}file3.txt
     Remove File    ${zipfilename}


### PR DESCRIPTION
The keyword "Create Zip From Files In Directory" can optionally include files in subdirectories, by calling with `sub_directories=${true}` (default value: false).

The keyword "Create Zip From Files In Directory" was always including files in subdirectories, now this can be overriden by calling with `sub_directories=${false}` (default value: true)

The default values have been set so, to preserve the existing behavior and usage.