### PR TITLE
[fix] zip file duplication bug

### DIFF
--- a/ArchiveLibrary/keywords.py
+++ b/ArchiveLibrary/keywords.py
@@ -130,7 +130,8 @@ class ArchiveKeywords:
 
         files = return_files_lists(directory, sub_directories)
         for filepath, name in files:
-            the_zip.write(filepath, arcname=name)
+            if name != os.path.basename(filename):
+                the_zip.write(filepath, arcname=name)
 
         the_zip.close()
 

--- a/atests/testcase.robot
+++ b/atests/testcase.robot
@@ -105,6 +105,16 @@ Create ZIP Package from files in directory and subdirectory with no compression
     Archive Should Contain File    ${zipfilename}    subdir${/}file3.txt
     Remove File    ${zipfilename}
 
+Create ZIP Package from files in same directory as files
+    ${zipfilename}=    set variable    ${CURDIR}${/}FilesToTar${/}newZipFile.zip
+    Remove File    ${zipfilename}
+    Create zip from Files in directory    ${CURDIR}${/}FilesToTar    ${zipfilename}
+    Archive Should Contain File    ${zipfilename}    file1.txt
+    Archive Should Contain File    ${zipfilename}    file2.txt
+    Run Keyword And Expect Error    *does not contain value 'newZipFile.zip'*    Archive Should Contain File    ${zipfilename}    newZipFile.zip
+    Run Keyword And Expect Error    *does not contain value 'subdir${/}file3.txt'*    Archive Should Contain File    ${zipfilename}    subdir${/}file3.txt
+    Remove File    ${zipfilename}
+
 Create ZIP Package from files in directory and subdirectory with compression deflated
     ${zipfilename}=    set variable    newZipFile.zip
     Remove File    ${zipfilename}


### PR DESCRIPTION
https://github.com/MarketSquare/robotframework-archivelibrary/issues/35
If the zip file was created in a files directory, the created zip contained its copy, which was corrupted.